### PR TITLE
Fix dynamic categories listing

### DIFF
--- a/_layouts/categories.html
+++ b/_layouts/categories.html
@@ -5,18 +5,17 @@ permalink: "/categories.html"
 ---
 
 <div class="row listrecent">
-    {% assign categories_list = "Inside Products, Product Analytics, Tech Stories, Project Lab, Career & Growth" | split: ", " %}
-    
-    {% for category in categories_list %}
+    {% for category in site.categories %}
     <div class="section-title col-md-12 mt-4">
-        <h2 id="{{ category | replace: " ","-" }}">Category <span class="text-capitalize">{{ category }}</span></h2>
+        <h2 id="{{ category[0] | replace: ' ', '-' }}">Category <span class="text-capitalize">{{ category[0] }}</span></h2>
     </div>
 
-    {% assign pages_list = site.categories[category] %}
+    {% assign pages_list = category[1] %}
     {% for post in pages_list %}
         {% if post.title %}
             {% include postbox.html %}
         {% endif %}
     {% endfor %}
+    {% assign pages_list = nil %}
     {% endfor %}
 </div>


### PR DESCRIPTION
## Summary
- fix the categories page to dynamically list all categories

## Testing
- `bundle exec jekyll build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843c9b63a548331ab862d12fd5d57e2