### PR TITLE
Add dark mode support

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -92,6 +92,9 @@
                 {% endfor %}
 
                 {% include search-lunr.html %}
+                <li class="nav-item d-flex align-items-center">
+                    <button id="theme-toggle" class="btn btn-sm btn-outline-secondary ml-2" type="button">🌓</button>
+                </li>
             </ul>
 
         <!-- End Menu -->
@@ -202,6 +205,7 @@
 {% if page.layout == 'post' %}
 <script id="dsq-count-scr" src="//{{site.disqus}}.disqus.com/count.js"></script>
 {% endif %}
+<script src="{{ site.baseurl }}/assets/js/theme-toggle.js"></script>
 
 <script>
 $(document).ready(function() {

--- a/_sass/_custom.scss
+++ b/_sass/_custom.scss
@@ -174,4 +174,13 @@ hr {
 
 // 폰트 import
 @import url('https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@400;500;700&display=swap');
-@import url('https://cdn.jsdelivr.net/gh/orioncactus/pretendard/dist/web/static/pretendard.css'); 
+@import url('https://cdn.jsdelivr.net/gh/orioncactus/pretendard/dist/web/static/pretendard.css');
+
+// Dark theme overrides
+[data-theme='dark'] {
+  --background-color: #121212;
+  --text-color: #e0e0e0;
+  --link-color: #70a1ff;
+  --hover-color: #a4b0ff;
+  --border-color: #333;
+}

--- a/assets/css/screen.css
+++ b/assets/css/screen.css
@@ -940,3 +940,8 @@ body { background: var(--bg-light); color: #222; }
 h1, h2, h3 { color: var(--primary-color); }
 strong, b, .highlight { color: var(--secondary-color); }
 .section-title span { border-bottom: 2px solid var(--primary-color); color: var(--primary-color); }
+[data-theme='dark'] {
+  --bg-light: #121212;
+  color: #e0e0e0;
+  background: var(--bg-light);
+}

--- a/assets/js/theme-toggle.js
+++ b/assets/js/theme-toggle.js
@@ -1,0 +1,18 @@
+(function(){
+  const body = document.body;
+  const stored = localStorage.getItem('theme');
+  if(stored === 'dark') body.setAttribute('data-theme','dark');
+  const btn = document.getElementById('theme-toggle');
+  if(btn){
+    btn.addEventListener('click', function(){
+      if(body.getAttribute('data-theme') === 'dark'){
+        body.removeAttribute('data-theme');
+        localStorage.removeItem('theme');
+      } else {
+        body.setAttribute('data-theme','dark');
+        localStorage.setItem('theme','dark');
+      }
+    });
+  }
+})();
+


### PR DESCRIPTION
## Summary
- add dark mode CSS variables
- include dark theme section in compiled CSS
- provide JavaScript to toggle dark mode
- add toggle button in navigation
- load new script in the layout

## Testing
- `bundle install --quiet` *(fails: Net::HTTPClientException 403 Forbidden)*
- `bundle exec jekyll build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684407d550308331ab43880019bbfc05