### PR TITLE
Update site language configuration

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -5,6 +5,7 @@ description: "기술 도입보다 정착에 집중하는 실무 중심 테크 �
 logo: 'assets/images/logo.png'
 favicon: 'assets/images/logo.png'
 baseurl: ""
+lang: ko
 google_analytics: G-LFFKMBQP12  # GA4 Tracking ID 'G-LFFKMBQP12'
 disqus: 'ltnalsxl'
 mailchimp-list: ''

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="{{ site.lang | default: 'en' }}">
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">


### PR DESCRIPTION
## Summary
- set default site language to Korean in `_config.yml`
- use Jekyll `site.lang` variable for the HTML `lang` attribute

## Testing
- `bundle exec jekyll build` *(fails: command not found)*
- `bundle install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68440de1cde483318580053d62f80c3e