### PR TITLE
Enhance about page

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -5,6 +5,7 @@ description: "기술 도입보다 정착에 집중하는 실무 중심 테크 �
 logo: 'assets/images/logo.png'
 favicon: 'assets/images/logo.png'
 baseurl: ""
+lang: ko
 google_analytics: G-LFFKMBQP12  # GA4 Tracking ID 'G-LFFKMBQP12'
 disqus: 'ltnalsxl'
 mailchimp-list: ''

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="{{ site.lang | default: 'en' }}">
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">

--- a/_pages/about.md
+++ b/_pages/about.md
@@ -4,11 +4,13 @@ title: "About | Tech That Sticks"
 permalink: /about/
 ---
 
-# 🎯 Tech That Sticks
+<div class="jumbotron jumbotron-fluid hero-gradient text-center text-white mb-4">
+  <div class="container">
+    <h1 class="display-4">Tech That Sticks</h1>
+    <p class="lead">기술이 머물고 뿌리내리는 과정을 연구합니다.</p>
+  </div>
+</div>
 
-> "기술은 '도입'보다 '정착'이 어렵습니다.  
-> 저는 사람들이 실제로 쓰는 기술을 설계하고,  
-> 스스로 쓸 수 있게 돕는 환경을 만드는 사람입니다."
 
 ## 🏷️ 브랜드 메시지
 

--- a/_sass/_custom.scss
+++ b/_sass/_custom.scss
@@ -172,6 +172,18 @@ hr {
   margin: 2rem 0;
 }
 
+// Hero gradient styling
+.hero-gradient {
+  background: linear-gradient(135deg, #2c7be5, #6c757d);
+  color: #fff;
+  animation: fadeIn 1.2s ease-in-out;
+}
+
+@keyframes fadeIn {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
 // 폰트 import
 @import url('https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@400;500;700&display=swap');
 @import url('https://cdn.jsdelivr.net/gh/orioncactus/pretendard/dist/web/static/pretendard.css');

--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@ layout: default
 ---
 
 <!-- Hero Section -->
-<div class="jumbotron jumbotron-fluid bg-light">
+<div class="jumbotron jumbotron-fluid hero-gradient">
     <div class="container">
         <h1 class="display-4">Tech That Sticks</h1>
         <p class="lead">기술 도입보다 정착에 집중하는 실무 중심 테크 블로그</p>


### PR DESCRIPTION
## Summary
- configure site language in `_config.yml`
- use site.lang for `<html>` tag
- style hero sections with a gradient
- apply the gradient on the homepage
- add gradient hero to the about page

## Testing
- `bundle install` *(fails: 403 Forbidden)*
- `bundle exec jekyll build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684406f208448331bedaf357764e11c6