### PR TITLE
Fix jekyll build error by excluding vendor

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -82,7 +82,7 @@ adsense-data-ad-slot: "1363087678"
 # Lazy Images ("enabled" or "disabled")
 lazyimages: "disabled"
 
-exclude: [changelog.md, LICENSE.txt, README.md, Gemfile, Gemfile.lock]
+exclude: [changelog.md, LICENSE.txt, README.md, Gemfile, Gemfile.lock, vendor]
 
 nav:
   - title: "Log"


### PR DESCRIPTION
## Summary
- exclude the `vendor` directory from Jekyll build so template posts do not trigger invalid dates

## Testing
- `bundle exec jekyll build` *(fails: bundler: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68445648ae3083319c67c033e90d59db