### PR TITLE
Apply about-style hero to homepage

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -37,10 +37,10 @@
 {% capture layout %}{% if page.layout %}layout-{{ page.layout }}{% endif %}{% endcapture %}
 <body class="{{layout}}">
 	<!-- defer loading of font and font awesome -->
-	<noscript id="deferred-styles">
-		<link href="https://fonts.googleapis.com/css?family=Righteous%7CMerriweather:300,300i,400,400i,700,700i" rel="stylesheet">
-		<link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.0.13/css/all.css" integrity="sha384-DNOHZ68U8hZfKXOrtjWvjxusGo9WQnrNx2sqG0tfsghAvtVlRW3tvkXWZh58N9jp" crossorigin="anonymous">
-	</noscript>
+        <noscript id="deferred-styles">
+                <link href="https://fonts.googleapis.com/css2?family=Google+Sans:wght@300;400;500;700&family=Roboto:wght@300;400;500;700&display=swap" rel="stylesheet">
+                <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.0.13/css/all.css" integrity="sha384-DNOHZ68U8hZfKXOrtjWvjxusGo9WQnrNx2sqG0tfsghAvtVlRW3tvkXWZh58N9jp" crossorigin="anonymous">
+        </noscript>
 
 
 <!-- Begin Menu Navigation

--- a/_sass/_custom.scss
+++ b/_sass/_custom.scss
@@ -1,17 +1,17 @@
-// 푸르고 깔끔한 색상 테마
+// Google inspired color theme
 :root {
-  --primary-color: #2c7be5;      // 메인 블루
-  --secondary-color: #6c757d;    // 보조 그레이
-  --accent-color: #00d4ff;       // 강조 블루
-  --background-color: #f8f9fa;   // 배경색
-  --text-color: #2c3e50;         // 텍스트 색상
-  --link-color: #2c7be5;         // 링크 색상
-  --hover-color: #1a68d1;        // 호버 색상
-  --border-color: #e9ecef;       // 테두리 색상
-  
-  // 폰트 설정
-  --font-primary: 'Noto Sans KR', -apple-system, BlinkMacSystemFont, system-ui, sans-serif;
-  --font-code: 'Pretendard', 'SF Mono', 'Consolas', 'Liberation Mono', Menlo, monospace;
+  --primary-color: #4285f4;      // Google blue
+  --secondary-color: #5f6368;    // subtle grey
+  --accent-color: #34a853;       // Google green
+  --background-color: #ffffff;   // white background
+  --text-color: #202124;         // dark grey text
+  --link-color: #1a73e8;         // link blue
+  --hover-color: #1557b0;        // link hover
+  --border-color: #dadce0;       // light border
+
+  // font settings
+  --font-primary: 'Google Sans', 'Roboto', sans-serif;
+  --font-code: 'Roboto Mono', Menlo, monospace;
 }
 
 // 기본 스타일
@@ -172,9 +172,130 @@ hr {
   margin: 2rem 0;
 }
 
-// 폰트 import
-@import url('https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@400;500;700&display=swap');
-@import url('https://cdn.jsdelivr.net/gh/orioncactus/pretendard/dist/web/static/pretendard.css');
+// Font imports
+@import url('https://fonts.googleapis.com/css2?family=Google+Sans:wght@300;400;500;700&family=Roboto:wght@300;400;500;700&family=Roboto+Mono:wght@400;500&display=swap');
+
+/* Hero Section */
+.hero {
+  height: 100vh;
+  display: flex;
+  align-items: center;
+  position: relative;
+  background: linear-gradient(135deg, #f8f9fa 0%, #e8f0fe 100%);
+  overflow: hidden;
+}
+
+.hero::before,
+.hero::after {
+  content: '';
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
+}
+
+.hero::before {
+  top: -50%;
+  right: -50%;
+  background: radial-gradient(circle, rgba(66, 133, 244, 0.1) 0%, transparent 70%);
+  animation: float 20s ease-in-out infinite;
+}
+
+.hero::after {
+  bottom: -50%;
+  left: -50%;
+  background: radial-gradient(circle, rgba(52, 168, 83, 0.1) 0%, transparent 70%);
+  animation: float 25s ease-in-out infinite reverse;
+}
+
+@keyframes float {
+  0%, 100% { transform: translateY(0) rotate(0deg); }
+  50% { transform: translateY(-20px) rotate(180deg); }
+}
+
+.hero-content {
+  z-index: 1;
+  max-width: 600px;
+}
+
+.hero h1 {
+  font-size: 56px;
+  font-weight: 400;
+  margin-bottom: 16px;
+  color: var(--text-color);
+  line-height: 1.2;
+  animation: slideInUp 1s ease;
+}
+
+.hero .subtitle {
+  font-size: 24px;
+  color: var(--secondary-color);
+  margin-bottom: 8px;
+  font-weight: 400;
+  animation: slideInUp 1s ease 0.2s both;
+}
+
+.hero .description {
+  font-size: 18px;
+  color: var(--secondary-color);
+  margin-bottom: 32px;
+  line-height: 1.5;
+  animation: slideInUp 1s ease 0.4s both;
+}
+
+.cta-buttons {
+  display: flex;
+  gap: 16px;
+  animation: slideInUp 1s ease 0.6s both;
+}
+
+.cta-button {
+  display: inline-flex;
+  align-items: center;
+  padding: 12px 24px;
+  text-decoration: none;
+  border-radius: 24px;
+  font-weight: 500;
+  transition: all 0.3s ease;
+  font-size: 14px;
+  gap: 8px;
+}
+
+.cta-button.primary {
+  background: #1a73e8;
+  color: #fff;
+  box-shadow: 0 2px 10px rgba(26, 115, 232, 0.3);
+}
+
+.cta-button.primary:hover {
+  background: #1557b0;
+  transform: translateY(-2px);
+  box-shadow: 0 4px 20px rgba(26, 115, 232, 0.4);
+}
+
+.cta-button.secondary {
+  background: #fff;
+  color: #1a73e8;
+  border: 1px solid #dadce0;
+  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
+}
+
+.cta-button.secondary:hover {
+  background: #f8f9fa;
+  transform: translateY(-2px);
+  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.15);
+}
+
+@keyframes slideInUp {
+  from {
+    opacity: 0;
+    transform: translateY(50px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
 
 // Dark theme overrides
 [data-theme='dark'] {

--- a/index.html
+++ b/index.html
@@ -3,14 +3,19 @@ layout: default
 ---
 
 <!-- Hero Section -->
-<div class="jumbotron jumbotron-fluid bg-light">
+<section class="hero">
     <div class="container">
-        <h1 class="display-4">Tech That Sticks</h1>
-        <p class="lead">기술 도입보다 정착에 집중하는 실무 중심 테크 블로그</p>
-        <hr class="my-4">
-        <p>실제로 쓰이는 기술, 자동화, BI, 템플릿, 실전 사례와 인사이트를 공유합니다.</p>
+        <div class="hero-content">
+            <h1>Tech That Sticks</h1>
+            <div class="subtitle">실무 중심 테크 블로그</div>
+            <div class="description">기술 도입보다 정착에 집중하는 인사이트와 프로젝트를 공유합니다.</div>
+            <div class="cta-buttons">
+                <a href="#recent-posts" class="cta-button primary">최근 포스트</a>
+                <a href="{{ site.baseurl }}/about/" class="cta-button secondary">About Me</a>
+            </div>
+        </div>
     </div>
-</div>
+</section>
 
 <!-- Main Categories -->
 <div class="container">
@@ -57,7 +62,7 @@ layout: default
 </div>
 
 <!-- Recent Posts -->
-<div class="container">
+<div class="container" id="recent-posts">
     <h2 class="mb-4">최근 포스트</h2>
     <div class="row">
         {% assign posts = site.posts | sort: 'date' | reverse %}


### PR DESCRIPTION
## Summary
- refresh color scheme and fonts with a Google inspired palette
- embed hero styles in the main stylesheet
- update font imports in the layout
- redesign index page hero using the about page look

## Testing
- `bundle exec jekyll build` *(fails: jekyll not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686870eaa06083318c5afdc2afd10f26