### PR TITLE
Add player name mapping and script

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,3 +21,15 @@ Copyright (C) 2019 Sal, https://www.wowthemes.net
 4. Make necessary changes, commit, push and open a pull request on GitHub.
 
 Thank you!
+
+## Player name mapping
+
+The `_data/player_name_map.json` file maps Korean player names to English equivalents. Use `scripts/update_players.py` to apply these mappings to your player datasets.
+
+Example usage:
+
+```bash
+python scripts/update_players.py players.json -o players_en.json
+```
+
+This will read `players.json`, add `name_en` fields when a Korean name matches the mapping file, and write the result to `players_en.json`.

--- a/_data/player_name_map.json
+++ b/_data/player_name_map.json
@@ -1,0 +1,6 @@
+[
+  {"ko": "김현수", "en": "Hyun-soo Kim"},
+  {"ko": "이정후", "en": "Jung-hoo Lee"},
+  {"ko": "최지만", "en": "Ji-man Choi"},
+  {"ko": "류현진", "en": "Hyun-jin Ryu"}
+]

--- a/scripts/update_players.py
+++ b/scripts/update_players.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+"""Add English player names using a mapping file."""
+
+import argparse
+import json
+from pathlib import Path
+
+
+def load_mapping(path: Path) -> dict:
+    with path.open(encoding='utf-8') as f:
+        data = json.load(f)
+    return {item['ko']: item['en'] for item in data}
+
+
+def update_players(players_path: Path, mapping: dict) -> list:
+    with players_path.open(encoding='utf-8') as f:
+        players = json.load(f)
+    for player in players:
+        ko_name = player.get('name_ko') or player.get('ko') or player.get('name')
+        if ko_name and ko_name in mapping:
+            player['name_en'] = mapping[ko_name]
+    return players
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description='Add English names to player JSON using mapping file.')
+    parser.add_argument('players', type=Path, help='Input players JSON file')
+    parser.add_argument('-m', '--mapping', type=Path, default=Path('_data/player_name_map.json'),
+                        help='Path to name mapping JSON')
+    parser.add_argument('-o', '--output', type=Path,
+                        help='Output file path (default: overwrite input)')
+    args = parser.parse_args()
+
+    mapping = load_mapping(args.mapping)
+    updated = update_players(args.players, mapping)
+    out_path = args.output or args.players
+    with out_path.open('w', encoding='utf-8') as f:
+        json.dump(updated, f, ensure_ascii=False, indent=2)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- create a player name mapping JSON with Korean and English names
- add `update_players.py` script to apply the mapping
- document usage in README

## Testing
- `bundle exec jekyll build` *(fails: `jekyll` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68687477fcc08331a882bd812d99aadb