### PR TITLE
Integrate About page with site layout

### DIFF
--- a/_pages/about.html
+++ b/_pages/about.html
@@ -1,16 +1,10 @@
 ---
-layout: null
+layout: default
+title: "About"
 permalink: /about/
 ---
 
-<!DOCTYPE html>
-<html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Sumin Lee - Data Engineer & IT Transformation Specialist</title>
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&display=swap" rel="stylesheet">
-    <style>
+<style>
         * {
             margin: 0;
             padding: 0;
@@ -756,27 +750,12 @@ permalink: /about/
             }
         }
     </style>
-</head>
-<body>
-    <div class="floating-shapes">
-        <div class="shape shape-1"></div>
-        <div class="shape shape-2"></div>
-        <div class="shape shape-3"></div>
-        <div class="shape shape-4"></div>
-    </div>
-
-    <header class="header">
-        <nav class="nav container">
-            <div class="logo">Sumin Lee</div>
-            <ul class="nav-links">
-                <li><a href="#about">About</a></li>
-                <li><a href="#skills">Skills</a></li>
-                <li><a href="#experience">Experience</a></li>
-                <li><a href="#projects">Projects</a></li>
-                <li><a href="#contact">Contact</a></li>
-            </ul>
-        </nav>
-    </header>
+<div class="floating-shapes">
+    <div class="shape shape-1"></div>
+    <div class="shape shape-2"></div>
+    <div class="shape shape-3"></div>
+    <div class="shape shape-4"></div>
+</div>
 
     <section class="hero">
         <div class="container">
@@ -1008,6 +987,5 @@ $(document).ready(function(){
   });
 });
 </script>
-</body>
-</html>
+
 


### PR DESCRIPTION
## Summary
- use the site's default layout for `about.html`
- remove standalone HTML structure so About page is part of the site navigation

## Testing
- `bundle exec jekyll build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6868791589788331b42c3daa4f3db64c