### PR TITLE
Add portfolio page

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -98,5 +98,7 @@ nav:
     url: "/categories/insights/"
   - title: "About"
     url: "/about/"
+  - title: "Portfolio"
+    url: "/portfolio/"
   - title: "Contact"
     url: "/contact/"

--- a/_pages/portfolio.md
+++ b/_pages/portfolio.md
@@ -1,0 +1,18 @@
+---
+layout: page
+title: "Portfolio"
+permalink: /portfolio/
+---
+
+# 🚀 Portfolio
+
+주요 프로젝트와 작업물들을 한눈에 볼 수 있습니다. 각 항목을 클릭하면 자세한 설명과 사용한 기술 스택을 확인할 수 있습니다.
+
+## Featured Projects
+
+- **Tech Adoption Guide**: 사내 기술 도입을 돕는 단계별 가이드와 자동화 스크립트
+- **BI Dashboard Implementation**: 데이터 시각화를 위한 대시보드 구축 사례
+- **Automation Studio**: 반복 업무를 자동화한 스크립트 모음
+
+더 많은 프로젝트는 [Project Lab](/categories/project-lab/)에서 확인할 수 있습니다.
+

--- a/index.html
+++ b/index.html
@@ -59,6 +59,17 @@ layout: default
             </div>
         </div>
     </div>
+    <div class="row mb-4">
+        <div class="col-md-12">
+            <div class="card mb-4">
+                <div class="card-body text-center">
+                    <h2 class="card-title">🚀 Portfolio</h2>
+                    <p class="card-text">주요 프로젝트와 작업물을 살펴보세요.</p>
+                    <a href="{{ site.baseurl }}/portfolio/" class="btn btn-primary">포트폴리오 보기</a>
+                </div>
+            </div>
+        </div>
+    </div>
 </div>
 
 <!-- Recent Posts -->


### PR DESCRIPTION
## Summary
- create a Portfolio page with sample projects
- link Portfolio in site navigation
- highlight Portfolio on the home page

## Testing
- `bundle install` *(fails: network restricted)*

------
https://chatgpt.com/codex/tasks/task_e_68687bf890148331ae8ada35151a8f20