### PR TITLE
Simplify theme colors

### DIFF
--- a/_sass/_custom.scss
+++ b/_sass/_custom.scss
@@ -1,15 +1,15 @@
-// Modern vibrant color theme
+// Simple grayscale color theme matching the logo
 :root {
-  --primary-color: #7f5af0;      // vibrant purple
-  --secondary-color: #72757e;    // neutral gray
-  --accent-color: #2cb67d;       // teal accent
+  --primary-color: #333333;      // dark gray
+  --secondary-color: #666666;    // medium gray
+  --accent-color: #0d6efd;       // blue accent
   --background-color: #ffffff;   // white background
-  --text-color: #16161a;         // dark text
-  --link-color: #7f5af0;         // primary as link color
-  --hover-color: #5d3fd3;        // darker purple
-  --border-color: #d0d7de;       // light border
-  --hero-gradient-start: #f7f7ff;   // subtle purple tint
-  --hero-gradient-end: #e8fff8;     // subtle teal tint
+  --text-color: #212529;         // dark text
+  --link-color: #0d6efd;         // accent link color
+  --hover-color: #0a58ca;        // darker blue
+  --border-color: #dee2e6;       // light border
+  --hero-gradient-start: #ffffff;   // plain white
+  --hero-gradient-end: #ffffff;     // plain white
 
   // font settings
   --font-primary: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;

--- a/assets/css/screen.css
+++ b/assets/css/screen.css
@@ -12,12 +12,12 @@ License: https://www.wowthemes.net/freebies-license/
 }
 
 a {
-    color: #00ab6b;
+    color: var(--link-color, #0d6efd);
     transition: all 0.2s;
 }
 
 a:hover {
-    color: #038252;
+    color: var(--hover-color, #0a58ca);
     text-decoration: none;
 }
 
@@ -926,15 +926,16 @@ iframe {
 }
 
 :root {
-  --primary-color: #2D5016;
-  --secondary-color: #FF8C42;
-  --accent-color: #5DADE2;
-  --bg-light: #f9f9f9;
+  --primary-color: #333333;
+  --secondary-color: #666666;
+  --accent-color: #0d6efd;
+  --hover-color: #0a58ca;
+  --bg-light: #ffffff;
 }
 
 body { background: var(--bg-light); color: #222; }
 .btn { background: var(--primary-color); color: #fff !important; border-radius: 6px; padding: 0.5em 1.2em; font-weight: 600; }
-.btn:hover { background: var(--secondary-color); }
+.btn:hover { background: var(--hover-color, #0a58ca); }
 .btn-secondary { background: var(--secondary-color); }
 .btn-accent { background: var(--accent-color); color: #fff !important; }
 h1, h2, h3 { color: var(--primary-color); }


### PR DESCRIPTION
## Summary
- replace vibrant palette with simple grayscale colors
- reference new color variables in default styles

## Testing
- `bundle exec jekyll build` *(fails: bundler command not found)*
- `bundle install` *(fails: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6868918ae5648331a60e0ddc600ea20c