### PR TITLE
Simplify theme colors

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -131,7 +131,7 @@
 ================================================== -->
 <div class="alertbar">
 	<div class="container text-center">
-		<span><img src="{{ site.baseurl }}/{{ site.logo }}" alt="{{site.title}}"> &nbsp; Never miss a <b>story</b> from us, subscribe to our newsletter</span>
+                <span>Never miss a <b>story</b> from us, subscribe to our newsletter</span>
         <form action="{{site.mailchimp-list}}" method="post" name="mc-embedded-subscribe-form" class="wj-contact-form validate" target="_blank" novalidate>
             <div class="mc-field-group">
             <input type="email" placeholder="Email" name="EMAIL" class="required email" id="mce-EMAIL" autocomplete="on" required>

--- a/_sass/_custom.scss
+++ b/_sass/_custom.scss
@@ -2,11 +2,11 @@
 :root {
   --primary-color: #333333;      // dark gray
   --secondary-color: #666666;    // medium gray
-  --accent-color: #0d6efd;       // blue accent
+  --accent-color: #333333;       // unified dark gray accent
   --background-color: #ffffff;   // white background
   --text-color: #212529;         // dark text
-  --link-color: #0d6efd;         // accent link color
-  --hover-color: #0a58ca;        // darker blue
+  --link-color: #333333;         // link color matches accent
+  --hover-color: #555555;        // slightly lighter on hover
   --border-color: #dee2e6;       // light border
   --hero-gradient-start: #ffffff;   // plain white
   --hero-gradient-end: #ffffff;     // plain white
@@ -101,7 +101,7 @@ a {
 }
 
 .card-title {
-  border-bottom: 2px solid var(--accent-color);
+  border-bottom: 2px solid var(--primary-color);
   padding-bottom: 0.5rem;
   margin-bottom: 0.75rem;
 }
@@ -125,7 +125,7 @@ h6 { font-size: var(--text-lg); }
 // 네비게이션 스타일
 
 .navbar {
-  background: linear-gradient(90deg, var(--primary-color) 0%, var(--accent-color) 100%);
+  background: var(--primary-color);
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
   border-bottom: none;
   font-family: var(--font-primary);
@@ -221,33 +221,7 @@ hr {
   overflow: hidden;
 }
 
-.hero::before,
-.hero::after {
-  content: '';
-  position: absolute;
-  width: 100%;
-  height: 100%;
-  pointer-events: none;
-}
-
-.hero::before {
-  top: -50%;
-  right: -50%;
-  background: radial-gradient(circle, rgba(127, 90, 240, 0.15) 0%, transparent 70%);
-  animation: float 20s ease-in-out infinite;
-}
-
-.hero::after {
-  bottom: -50%;
-  left: -50%;
-  background: radial-gradient(circle, rgba(44, 182, 125, 0.15) 0%, transparent 70%);
-  animation: float 25s ease-in-out infinite reverse;
-}
-
-@keyframes float {
-  0%, 100% { transform: translateY(0) rotate(0deg); }
-  50% { transform: translateY(-20px) rotate(180deg); }
-}
+/* remove animated color shapes for a cleaner look */
 
 .hero-content {
   z-index: 1;
@@ -300,13 +274,13 @@ hr {
 .cta-button.primary {
   background: var(--primary-color);
   color: #fff;
-  box-shadow: 0 2px 10px rgba(127, 90, 240, 0.3);
+  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
 }
 
 .cta-button.primary:hover {
   background: var(--hover-color);
   transform: translateY(-2px);
-  box-shadow: 0 4px 20px rgba(127, 90, 240, 0.4);
+  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.15);
 }
 
 .cta-button.secondary {
@@ -337,7 +311,7 @@ hr {
 [data-theme='dark'] {
   --background-color: #0d0d0f;
   --text-color: #d7d7db;
-  --link-color: #7f5af0;
-  --hover-color: #a78bfa;
+  --link-color: #bbbbbb;
+  --hover-color: #ffffff;
   --border-color: #2e2e33;
 }

--- a/assets/css/screen.css
+++ b/assets/css/screen.css
@@ -12,12 +12,12 @@ License: https://www.wowthemes.net/freebies-license/
 }
 
 a {
-    color: var(--link-color, #0d6efd);
+    color: var(--link-color, #333333);
     transition: all 0.2s;
 }
 
 a:hover {
-    color: var(--hover-color, #0a58ca);
+    color: var(--hover-color, #555555);
     text-decoration: none;
 }
 
@@ -546,8 +546,8 @@ ul.tags li a:hover {
 }
 
 .btn.follow {
-    border-color: #02B875;
-    color: #1C9963;
+    border-color: #333333;
+    color: #333333;
     padding: 3px 10px;
     text-align: center;
     border-radius: 999em;
@@ -556,8 +556,8 @@ ul.tags li a:hover {
 }
 
 .btn.subscribe {
-    background-color: #1C9963;
-    border-color: #1C9963;
+    background-color: #333333;
+    border-color: #333333;
     color: rgba(255, 255, 255, 1);
     fill: rgba(255, 255, 255, 1);
     border-radius: 30px;
@@ -602,8 +602,8 @@ ul.tags li a:hover {
 }
 
 .alertbar input[type="submit"] {
-    background-color: #1C9963;
-    border: 1px solid #1C9963;
+    background-color: #333333;
+    border: 1px solid #333333;
     color: rgba(255, 255, 255, 1);
     fill: rgba(255, 255, 255, 1);
     font-size: 0.85rem;
@@ -881,14 +881,14 @@ iframe {
 :root {
   --primary-color: #333333;
   --secondary-color: #666666;
-  --accent-color: #0d6efd;
-  --hover-color: #0a58ca;
+  --accent-color: #333333;
+  --hover-color: #555555;
   --bg-light: #ffffff;
 }
 
 body { background: var(--bg-light); color: #222; }
 .btn { background: var(--primary-color); color: #fff !important; border-radius: 6px; padding: 0.5em 1.2em; font-weight: 600; }
-.btn:hover { background: var(--hover-color, #0a58ca); }
+.btn:hover { background: var(--hover-color, #555555); }
 .btn-secondary { background: var(--secondary-color); }
 .btn-accent { background: var(--accent-color); color: #fff !important; }
 h1, h2, h3 { color: var(--primary-color); }


### PR DESCRIPTION
## Summary
- remove logo from the scroll-triggered subscribe bar
- keep all colors monochrome for a cleaner look
- tone down button styling and hero background decorations

## Testing
- `bundle exec jekyll build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686892f7df78833181b58d2845e88e78