### PR TITLE
Improve dark mode visuals

### DIFF
--- a/_sass/_custom.scss
+++ b/_sass/_custom.scss
@@ -337,7 +337,19 @@ hr {
 [data-theme='dark'] {
   --background-color: #0d0d0f;
   --text-color: #d7d7db;
-  --link-color: #7f5af0;
-  --hover-color: #a78bfa;
+  --link-color: #9ec5fe; /* lighter link color for dark mode */
+  --hover-color: #bfd3ff; /* lighter hover color */
+  --accent-color: #4d9efb; /* softened accent */
   --border-color: #2e2e33;
+
+  /* improve visibility of icons and logos */
+  .share ul li i.fa,
+  .refresh-btn {
+    color: var(--text-color);
+    border-color: var(--border-color);
+  }
+
+  img.team-logo {
+    filter: invert(1) brightness(1.2);
+  }
 }

--- a/assets/css/screen.css
+++ b/assets/css/screen.css
@@ -896,6 +896,18 @@ strong, b, .highlight { color: var(--secondary-color); }
 .section-title span { border-bottom: 2px solid var(--primary-color); color: var(--primary-color); }
 [data-theme='dark'] {
   --bg-light: #121212;
+  --accent-color: #4d9efb;
+  --hover-color: #bfd3ff;
   color: #e0e0e0;
   background: var(--bg-light);
+}
+
+[data-theme='dark'] .share ul li i.fa,
+[data-theme='dark'] .refresh-btn {
+  color: var(--text-color, #e0e0e0);
+  border-color: var(--border-color, #444);
+}
+
+[data-theme='dark'] img.team-logo {
+  filter: invert(1) brightness(1.2);
 }


### PR DESCRIPTION
## Summary
- tweak dark theme variables for better contrast
- adjust share/refresh icons and team logo visibility in dark mode

## Testing
- `bundle install` *(fails: Net::HTTPClientException 403 "Forbidden")*


------
https://chatgpt.com/codex/tasks/task_e_68689482cb1c83319770813bbd92ec63