### PR TITLE
Enable lazy loading

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -80,7 +80,7 @@ adsense-data-ad-client: "ca-pub-3412143450191416"
 adsense-data-ad-slot: "1363087678"
 
 # Lazy Images ("enabled" or "disabled")
-lazyimages: "disabled"
+lazyimages: "enabled"
 
 exclude: [changelog.md, LICENSE.txt, README.md, Gemfile, Gemfile.lock, vendor]
 


### PR DESCRIPTION
## Summary
- enable lazy loading of images via `_config.yml`

## Testing
- `bundle install` *(fails: 403 Forbidden)*


------
https://chatgpt.com/codex/tasks/task_e_686897bc316c833198abf929f385dc60