### PR TITLE
Add client-side search

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -91,6 +91,14 @@
                 </li>
                 {% endfor %}
 
+                <li class="nav-item">
+                    <form class="form-inline position-relative">
+                        <input id="search-input" class="form-control" type="search" placeholder="Search" aria-label="Search">
+                        <button class="btn search-icon" type="button"><i class="fa fa-search"></i></button>
+                        <ul id="search-results" class="list-group position-absolute w-100"></ul>
+                    </form>
+                </li>
+
                 <li class="nav-item d-flex align-items-center">
                     <button id="theme-toggle" class="btn btn-sm btn-outline-secondary ml-2" type="button">🌓</button>
                 </li>
@@ -170,12 +178,14 @@
 <script src="{{ site.baseurl }}/assets/js/lazyload.js"></script>
 {% endif %}
 
-<script src="{{ site.baseurl }}/assets/js/ie10-viewport-bug-workaround.js"></script> 
+<script src="{{ site.baseurl }}/assets/js/ie10-viewport-bug-workaround.js"></script>
 
 {% if page.layout == 'post' %}
 <script id="dsq-count-scr" src="//{{site.disqus}}.disqus.com/count.js"></script>
 {% endif %}
 <script src="{{ site.baseurl }}/assets/js/theme-toggle.js"></script>
+<script src="{{ site.baseurl }}/assets/js/lunr.min.js"></script>
+<script src="{{ site.baseurl }}/assets/js/search.js"></script>
 
 <script>
 $(document).ready(function() {

--- a/_sass/_custom.scss
+++ b/_sass/_custom.scss
@@ -315,3 +315,9 @@ hr {
   --hover-color: #ffffff;
   --border-color: #2e2e33;
 }
+
+#search-results {
+  max-height: 300px;
+  overflow-y: auto;
+  z-index: 1000;
+}

--- a/assets/css/screen.css
+++ b/assets/css/screen.css
@@ -899,3 +899,9 @@ strong, b, .highlight { color: var(--secondary-color); }
   color: #e0e0e0;
   background: var(--bg-light);
 }
+
+#search-results {
+  max-height: 300px;
+  overflow-y: auto;
+  z-index: 1000;
+}

--- a/assets/js/lunr.min.js
+++ b/assets/js/lunr.min.js
@@ -1,0 +1,14 @@
+(function(global){
+  function SimpleLunr(docs){
+    this.docs = docs || [];
+  }
+  SimpleLunr.prototype.search = function(q){
+    q = (q || '').toLowerCase();
+    return this.docs.filter(function(d){
+      var t = (d.title || '').toLowerCase();
+      var c = (d.content || '').toLowerCase();
+      return t.indexOf(q) !== -1 || c.indexOf(q) !== -1;
+    });
+  };
+  global.SimpleLunr = SimpleLunr;
+})(this);

--- a/assets/js/search.js
+++ b/assets/js/search.js
@@ -1,0 +1,35 @@
+---
+---
+(function($){
+  var index = null;
+  var baseurl = '';
+  function loadIndex(){
+    return $.getJSON(baseurl + '/search.json').done(function(data){
+      index = new SimpleLunr(data);
+    });
+  }
+  function render(results){
+    var $list = $('#search-results');
+    $list.empty();
+    if(!results.length){
+      $list.append('<li class="list-group-item">No results</li>');
+      return;
+    }
+    results.slice(0,10).forEach(function(r){
+      var item = $('<li class="list-group-item">');
+      item.append($('<a>').attr('href', r.url).text(r.title));
+      $list.append(item);
+    });
+  }
+  $(document).ready(function(){
+    baseurl = '{{ site.baseurl }}';
+    loadIndex();
+    $('#search-input').on('input', function(){
+      var q = $(this).val();
+      if(!q){ $('#search-results').empty(); return; }
+      if(index){
+        render(index.search(q));
+      }
+    });
+  });
+})(jQuery);

--- a/search.json
+++ b/search.json
@@ -1,0 +1,12 @@
+---
+layout: null
+---
+[
+{% for post in site.posts %}
+  {
+    "title": {{ post.title | jsonify }},
+    "url": "{{ post.url | relative_url }}",
+    "content": {{ post.content | strip_html | replace: '\n', ' ' | jsonify }}
+  }{% unless forloop.last %},{% endunless %}
+{% endfor %}
+]


### PR DESCRIPTION
## Summary
- include basic Lunr-like search in assets
- wire up search input in default layout
- generate search.json for indexing posts
- style search results

## Testing
- `bundle exec jekyll build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686897bd1b90833185d707ca76f40a0c