### PR TITLE
Revert hero gradient color

### DIFF
--- a/_sass/_custom.scss
+++ b/_sass/_custom.scss
@@ -8,8 +8,8 @@
   --link-color: #333333;         // link color matches accent
   --hover-color: #555555;        // slightly lighter on hover
   --border-color: #dee2e6;       // light border
-  --hero-gradient-start: #e0eafc;   // soft blue start
-  --hero-gradient-end: #cfdef3;     // soft blue end
+  --hero-gradient-start: #ffffff;   // plain white
+  --hero-gradient-end: #ffffff;     // plain white
 
   // font settings
   --font-primary: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;


### PR DESCRIPTION
## Summary
- revert hero background gradient to white

## Testing
- `bundle exec jekyll build` *(fails: jekyll missing)*
- `bundle install` *(fails: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_686898de73f483319b3a4e827a3a097b