### PR TITLE
Fix search results overlay

### DIFF
--- a/_sass/_custom.scss
+++ b/_sass/_custom.scss
@@ -329,4 +329,5 @@ hr {
   max-height: 300px;
   overflow-y: auto;
   z-index: 1000;
+  top: 100%;
 }

--- a/assets/css/screen.css
+++ b/assets/css/screen.css
@@ -884,4 +884,5 @@ strong, b, .highlight { color: var(--secondary-color); }
   max-height: 300px;
   overflow-y: auto;
   z-index: 1000;
+  top: 100%;
 }


### PR DESCRIPTION
## Summary
- ensure search results display below search field

## Testing
- `bundle exec jekyll build` *(fails: `bundler: command not found: jekyll`)*
- `bundle install` *(fails: Net::HTTPClientException 403 "Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_6868dd72a1fc8331a9e7b23f9795159f